### PR TITLE
Add Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
-sudo: false
-
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `laravel-youtrack-sdk` will be documented in this file.
 
 - Laravel 5.8 support
 
+### Removed
+
+- Laravel 5.4, 5.5, 5.6, 5.7 support
+
 ### Changed
 
 - Make all classes final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `laravel-youtrack-sdk` will be documented in this file.
 
+## 5.0.0 - 2019-03-18
+
+### Added
+
+- Laravel 5.8 support
+
+### Changed
+
+- Make all classes final
+- Moved service provider from `Cog\Laravel\YouTrack\Providers\YouTrackServiceProvider` to `Cog\Laravel\YouTrack\YouTrackServiceProvider`
+
 ## 4.2.0 - 2018-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,20 +65,12 @@ Once composer is installed, execute the following command in your project root t
 $ composer require cybercog/laravel-youtrack-sdk
 ```
 
-If you are using Laravel 5.4 or lower - include the service provider within `app/config/app.php`:
-
-```php
-'providers' => [
-    Cog\Laravel\YouTrack\Providers\YouTrackServiceProvider::class,
-],
-```
-
 ## Configuration
 
 Laravel YouTrack SDK designed to work with default config, but it always could be modified. First of all publish it:
 
 ```bash
-php artisan vendor:publish --provider="Cog\Laravel\YouTrack\Providers\YouTrackServiceProvider" --tag="config"
+php artisan vendor:publish --tag="youtrack-config"
 ```
 
 This will create a `config/youtrack.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.

--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,11 @@
     "require": {
         "php": "^7.1",
         "cybercog/youtrack-php-sdk": "^4.0",
-        "illuminate/support": "~5.4|~5.5|~5.6|~5.7|~5.8"
+        "illuminate/support": "5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
-        "phpunit/phpunit": "^5.7|^6.0|^7.0|^8.0"
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -57,17 +57,9 @@
     },
     "scripts": {
         "test-install": [
-            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.4",
-            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.5",
-            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.6",
-            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.7",
             "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.8"
         ],
         "test": [
-            "./vendor/bin/phpunit --configuration tests/framework/5.4",
-            "./vendor/bin/phpunit --configuration tests/framework/5.5",
-            "./vendor/bin/phpunit --configuration tests/framework/5.6",
-            "./vendor/bin/phpunit --configuration tests/framework/5.7",
             "./vendor/bin/phpunit --configuration tests/framework/5.8"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,11 @@
     "require": {
         "php": "^7.1",
         "cybercog/youtrack-php-sdk": "^4.0",
-        "illuminate/support": "~5.4|~5.5|~5.6|~5.7"
+        "illuminate/support": "~5.4|~5.5|~5.6|~5.7|~5.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
-        "phpunit/phpunit": "^5.7|^6.0|^7.0"
+        "phpunit/phpunit": "^5.7|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -60,13 +60,15 @@
             "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.4",
             "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.5",
             "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.6",
-            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.7"
+            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.7",
+            "composer install --prefer-dist --no-interaction --working-dir tests/framework/5.8"
         ],
         "test": [
             "./vendor/bin/phpunit --configuration tests/framework/5.4",
             "./vendor/bin/phpunit --configuration tests/framework/5.5",
             "./vendor/bin/phpunit --configuration tests/framework/5.6",
-            "./vendor/bin/phpunit --configuration tests/framework/5.7"
+            "./vendor/bin/phpunit --configuration tests/framework/5.7",
+            "./vendor/bin/phpunit --configuration tests/framework/5.8"
         ]
     },
     "config": {
@@ -75,7 +77,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Cog\\Laravel\\YouTrack\\Providers\\YouTrackServiceProvider"
+                "Cog\\Laravel\\YouTrack\\YouTrackServiceProvider"
             ]
         }
     },

--- a/config/youtrack.php
+++ b/config/youtrack.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel YouTrack SDK.
  *
@@ -10,6 +8,8 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 return [
 

--- a/src/YouTrackServiceProvider.php
+++ b/src/YouTrackServiceProvider.php
@@ -54,7 +54,7 @@ final class YouTrackServiceProvider extends ServiceProvider
         $source = realpath(__DIR__ . '/../config/youtrack.php');
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([$source => config_path('youtrack.php')], 'config');
+            $this->publishes([$source => config_path('youtrack.php')], 'youtrack-config');
         } elseif ($this->app instanceof LumenApplication) {
             $this->app->configure('youtrack');
         }

--- a/src/YouTrackServiceProvider.php
+++ b/src/YouTrackServiceProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel YouTrack SDK.
  *
@@ -11,7 +9,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\Laravel\YouTrack\Providers;
+declare(strict_types=1);
+
+namespace Cog\Laravel\YouTrack;
 
 use Cog\Contracts\YouTrack\Rest\Authorizer\Authorizer as AuthorizerContract;
 use Cog\Contracts\YouTrack\Rest\Client\Client as ClientContract;
@@ -24,29 +24,19 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Laravel\Lumen\Application as LumenApplication;
 
-/**
- * Class YouTrackServiceProvider.
- *
- * @package Cog\Laravel\YouTrack\Providers
- */
-class YouTrackServiceProvider extends ServiceProvider
+final class YouTrackServiceProvider extends ServiceProvider
 {
-    /**
-     * Perform post-registration booting of services.
-     *
-     * @return void
-     */
+    public function register(): void
+    {
+        $this->registerBindings();
+    }
+
     public function boot(): void
     {
         $this->bootConfig();
     }
 
-    /**
-     * Register bindings in the container.
-     *
-     * @return void
-     */
-    public function register(): void
+    private function registerBindings(): void
     {
         $this->app->bind(ClientContract::class, function () {
             $config = $this->app->make(ConfigContract::class);
@@ -55,18 +45,13 @@ class YouTrackServiceProvider extends ServiceProvider
                 'base_uri' => $config->get('youtrack.base_uri'),
             ]));
 
-            return new YouTrackClient($httpClient, $this->resolveAuthorizer($config));
+            return new YouTrackClient($httpClient, $this->resolveAuthorizerDriver($config));
         });
     }
 
-    /**
-     * Boot Laravel or Lumen config.
-     *
-     * @return void
-     */
-    protected function bootConfig(): void
+    private function bootConfig(): void
     {
-        $source = realpath(__DIR__ . '/../../config/youtrack.php');
+        $source = realpath(__DIR__ . '/../config/youtrack.php');
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
             $this->publishes([$source => config_path('youtrack.php')], 'config');
@@ -77,13 +62,7 @@ class YouTrackServiceProvider extends ServiceProvider
         $this->mergeConfigFrom($source, 'youtrack');
     }
 
-    /**
-     * Resolve Authorizer driver.
-     *
-     * @param \Illuminate\Contracts\Config\Repository $config
-     * @return \Cog\Contracts\YouTrack\Rest\Authorizer\Authorizer
-     */
-    protected function resolveAuthorizer(ConfigContract $config): AuthorizerContract
+    private function resolveAuthorizerDriver(ConfigContract $config): AuthorizerContract
     {
         $authorizer = $config->get('youtrack.authorizer');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel YouTrack SDK.
  *
@@ -11,16 +9,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\YouTrack;
 
-use Cog\Laravel\YouTrack\Providers\YouTrackServiceProvider;
+use Cog\Laravel\YouTrack\YouTrackServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-/**
- * Class TestCase.
- *
- * @package Cog\Tests\Laravel\YouTrack
- */
 abstract class TestCase extends Orchestra
 {
     /**
@@ -29,7 +24,7 @@ abstract class TestCase extends Orchestra
      * @param \Illuminate\Foundation\Application $app
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             YouTrackServiceProvider::class,

--- a/tests/Unit/Providers/YouTrackServiceProviderTest.php
+++ b/tests/Unit/Providers/YouTrackServiceProviderTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel YouTrack SDK.
  *
@@ -11,18 +9,15 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\YouTrack\Unit\Providers;
 
 use Cog\Contracts\YouTrack\Rest\Client\Client as ClientContract;
 use Cog\Tests\Laravel\YouTrack\TestCase;
 use Cog\YouTrack\Rest\Client\YouTrackClient;
 
-/**
- * Class YouTrackServiceProviderTest.
- *
- * @package Cog\Tests\Laravel\YouTrack\Unit\Providers
- */
-class YouTrackServiceProviderTest extends TestCase
+final class YouTrackServiceProviderTest extends TestCase
 {
     /** @test */
     public function it_can_instantiate_youtrack_client_from_container()

--- a/tests/framework/5.8/composer.json
+++ b/tests/framework/5.8/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "illuminate/support": "5.8.*"
+    },
+    "require-dev": {
+        "orchestra/testbench": "3.8.*"
+    }
+}

--- a/tests/framework/5.8/phpunit.xml.dist
+++ b/tests/framework/5.8/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite name="Package">
+            <directory suffix="Test.php">../../Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="YOUTRACK_BASE_URI" value="https://youtrack.example.com"/>
+        <env name="YOUTRACK_AUTH" value="token"/>
+        <env name="YOUTRACK_TOKEN" value=""/>
+        <env name="YOUTRACK_USERNAME" value=""/>
+        <env name="YOUTRACK_PASSWORD" value=""/>
+        <env name="YOUTRACK_PROJECT" value="TEST"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
Dropping all Laravel versions below 5.8 support because those tests cannot be executed and if there is a need people can still use v4 version for old Laravel versions.